### PR TITLE
Improved GET and POST /v1/communities

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -69,7 +69,7 @@ export async function getCommunityByTitleIDs(titleIDs: string[]): Promise<Hydrat
 	verifyConnected();
 
 	return Community.findOne({
-		title_ids: { $in: titleIDs }
+		title_id: { $in: titleIDs }
 	});
 }
 

--- a/src/models/community.ts
+++ b/src/models/community.ts
@@ -31,6 +31,7 @@ const CommunitySchema = new Schema<ICommunity, CommunityModel, ICommunityMethods
 		type: [Number],
 		default: undefined
 	},
+	owner: Number,
 	created_at: {
 		type: Date,
 		default: new Date(),
@@ -98,10 +99,10 @@ CommunitySchema.method('json', function json(): Record<string, any> {
 		community_id: this.community_id,
 		name: this.name,
 		description: this.description,
-		icon: '',
+		icon: this.icon.replace(/[^A-Za-z0-9+/=\s]/g, ''),
 		icon_3ds: '',
-		pid: '',
-		app_data: this.app_data,
+		pid: this.owner || '',
+		app_data: this.app_data.replace(/[^A-Za-z0-9+/=\s]/g, ''),
 		is_user_community: '0'
 	};
 });

--- a/src/types/mongoose/community.ts
+++ b/src/types/mongoose/community.ts
@@ -40,6 +40,6 @@ export interface ICommunityMethods {
 
 interface ICommunityQueryHelpers {}
 
-export type CommunityModel = Model<ICommunity, ICommunityQueryHelpers, ICommunityMethods>
+export interface CommunityModel extends Model<ICommunity, ICommunityQueryHelpers, ICommunityMethods> {}
 
 export type HydratedCommunityDocument = HydratedDocument<ICommunity, ICommunityMethods>

--- a/src/types/mongoose/community.ts
+++ b/src/types/mongoose/community.ts
@@ -16,6 +16,7 @@ export interface ICommunity {
     type: COMMUNITY_TYPE;
     parent: string;
     admins: Types.Array<number>;
+    owner: number;
     created_at: Date;
     empathy_count: number;
     followers: number;
@@ -39,6 +40,6 @@ export interface ICommunityMethods {
 
 interface ICommunityQueryHelpers {}
 
-export interface CommunityModel extends Model<ICommunity, ICommunityQueryHelpers, ICommunityMethods> {}
+export type CommunityModel = Model<ICommunity, ICommunityQueryHelpers, ICommunityMethods>
 
 export type HydratedCommunityDocument = HydratedDocument<ICommunity, ICommunityMethods>

--- a/src/types/mongoose/subcommunity-query.ts
+++ b/src/types/mongoose/subcommunity-query.ts
@@ -1,0 +1,9 @@
+// TODO - Make this more generic
+
+export interface SubCommunityQuery {
+	parent: string;
+	owner?: number;
+	olive_community_id?: {
+		$in: string[]
+	}
+}


### PR DESCRIPTION
- Added an optional 'owner' field to "Communities"

This is because Miiverse allowed user-made communities (4 per games)

- Added a subcommunity query

'parent' mandatory field to get all subcommunities belonging to a specific parent community

'owner' optional field to comply with 'my' query type

'olive_community_id' optional array field to comply with 'favorite' query type, you would feed this field the user favorite sub communities ID

- Fixed CommunitySchema 'json()' method for base64 fields

- Fixed getCommunityByTitleIDs(), there is no field 'title_ids' in the schema